### PR TITLE
🐞 Fix : 일부 폰트미적용 이슈- 폰트 import 위치 수정

### DIFF
--- a/src/style/GlobalStyle.js
+++ b/src/style/GlobalStyle.js
@@ -1,10 +1,6 @@
 import { createGlobalStyle } from 'styled-components';
 
 const GlobalStyle = createGlobalStyle`
-    /*======== Import Fonts ========*/
-    @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/variable/pretendardvariable.css");
-    
-    
     /*======== Variable CSS ========*/
     :root {
         /*---------- Color ----------*/

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -1,3 +1,5 @@
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/variable/pretendardvariable.css');
+
 /*=== reset css ===*/
 html,
 body,


### PR DESCRIPTION
createGlobalStyle 내에서 css import 사용 지양 경고문구에 따라 폰트 import 위치를 index.css로 변경

> ### 잠깐! PR하기 전에 확인해주세요!

✅ PR 제목의 형식을 잘 작성했나요?(커밋메시지 컨벤션과 동일)   
✅ 불필요한 코드를 제거했나요?   
✅ 작업 시작 전 후로 develop브랜치가 최신상태임을 확인했나요?   
✅ 라벨은 등록했나요?   
<br>

✨ PR 한 줄 요약
-------------------------------------------------
일부 폰트미적용 이슈- 폰트 import 위치 수정

<br>
<br>

🛠 상세 작업 내용
-------------------------------------------------  
createGlobalStyle 내에서 css import 사용 지양 경고문구에 따라 폰트 import 위치를 index.css로 변경

<br>
<br>

📸 참고 사항
-------------------------------------------------
<!--여기에 작성해주세요-->

<br>
<br>


💡 관련 이슈
-------------------------------------------------
<!--여기에 작성해주세요-->

<br>
<br>
