### PR TITLE
🎨 Style : 공통컴포넌트 UI(버튼,헤더) 타입과 사이즈별로 구현(#12)

### DIFF
--- a/src/components/common/button/Button.jsx
+++ b/src/components/common/button/Button.jsx
@@ -1,1 +1,26 @@
-temp = 0;
+import React from 'react';
+import { ShadowButton, BasicButton, BASIC_BTN, SHADOW_BTN, BorderButton, BORDER_BTN } from './Button.style';
+
+export default function Button({ size, vari, type, text, onClick, disabled }) {
+  //버튼사이즈종류 : lg,md,sm,xs,md-shadow,sm-shadow,md-border,sm-border,xs-border
+  switch (vari) {
+    case 'shadow':
+      return (
+        <ShadowButton $size={SHADOW_BTN[size]} type={type} onClick={onClick} disabled={disabled}>
+          {text}
+        </ShadowButton>
+      );
+    case 'border':
+      return (
+        <BorderButton $size={BORDER_BTN[size]} type={type} onClick={onClick} disabled={disabled}>
+          {text}
+        </BorderButton>
+      );
+    default:
+      return (
+        <BasicButton $size={BASIC_BTN[size]} type={type} onClick={onClick} disabled={disabled}>
+          {text}
+        </BasicButton>
+      );
+  }
+}

--- a/src/components/common/button/Button.jsx
+++ b/src/components/common/button/Button.jsx
@@ -12,7 +12,7 @@ export default function Button({ size, vari, type, text, onClick, disabled }) {
       );
     case 'border':
       return (
-        <BorderButton $size={BORDER_BTN[size]} type={type} onClick={onClick} disabled={disabled}>
+        <BorderButton $size={BORDER_BTN[size]} $pink={size === 'sm' && true} type={type} onClick={onClick} disabled={disabled}>
           {text}
         </BorderButton>
       );

--- a/src/components/common/button/Button.style.jsx
+++ b/src/components/common/button/Button.style.jsx
@@ -1,1 +1,92 @@
-temp = 0;
+import { css, styled } from 'styled-components';
+
+export const BASIC_BTN = {
+  xs: css`
+    width: 56px;
+    height: 28px;
+    border-radius: 26px;
+    font-size: 12px;
+  `,
+  sm: css`
+    width: 90px;
+    height: 32px;
+    border-radius: 32px;
+    font-size: 14px;
+  `,
+  md: css`
+    width: 120px;
+    height: 34px;
+    border-radius: 30px;
+    font-size: 14px;
+  `,
+  lg: css`
+    width: 322px;
+    height: 44px;
+    border-radius: 44px;
+    font-size: 14px;
+  `,
+};
+
+export const SHADOW_BTN = {
+  sm: css`
+    width: 78px;
+  `,
+  md: css`
+    width: 94px;
+  `,
+};
+
+export const BORDER_BTN = {
+  md: css`
+    width: 120px;
+    height: 34px;
+    border-radius: 30px;
+    font-size: 14px;
+  `,
+  sm: css`
+    width: 100px;
+    height: 34px;
+    border-radius: 30px;
+    font-size: 14px;
+  `,
+  xs: css`
+    width: 56px;
+    height: 28px;
+    border-radius: 26px;
+    font-size: 12px;
+  `,
+};
+
+export const BasicButton = styled.button`
+  background-color: var(--main-color-01);
+  color: var(--white);
+  ${(props) => props.$size}
+
+  &:disabled {
+    background-color: var(--main-color-02);
+    cursor: default;
+  }
+`;
+
+export const ShadowButton = styled.button`
+  height: 28px;
+  border-radius: 44px;
+  background-color: var(--white);
+  color: var(--black);
+  font-size: 14px;
+  box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.25);
+  ${(props) => props.$size}
+
+  //포커대신 다른 프롭스로 대체해야할듯
+  &:focus {
+    background-color: var(--main-color-01);
+    color: var(--white);
+  }
+`;
+
+export const BorderButton = styled.button`
+  border: 1px solid ${(props) => (props.$pink ? 'var(--main-color-01)' : 'var(--gray-02)')};
+  color: ${(props) => (props.$pink ? 'var(--main-color-01)' : 'var(--gray-02)')};
+  background-color: var(--white);
+  ${(props) => props.$size}
+`;

--- a/src/components/common/header/Header.jsx
+++ b/src/components/common/header/Header.jsx
@@ -1,26 +1,52 @@
 import React from 'react';
-import { BackBtn, Container, Logo, SearchBtn, SerachInput } from './Header.style';
-import { useLocation } from 'react-router';
+import { BackBtn, CenterText, Container, EditBtn, LeftText, Logo, SearchBtn, SerachInput } from 'components/common/header/Header.style';
 import logo from 'assets/images/logo_oguogu.png';
+import Button from 'components/common/button/Button';
 
-export default function Header({ type }) {
+export default function Header({ type, text, btnText, rightOnClick, leftOnClick }) {
   switch (type) {
     case 'home':
       return (
-        <Container>
+        <Container $justify="space-between">
           <h1 className="a11y-hidden">오구오구 홈화면</h1>
           <Logo src={logo} />
-          <SearchBtn />
+          <SearchBtn onClick={rightOnClick} />
         </Container>
       );
     case 'search':
       return (
-        <Container>
-          <BackBtn />
+        <Container $justify="space-between">
+          <BackBtn type="button" onClick={leftOnClick} />
           <SerachInput placeholder="계정 검색" />
         </Container>
       );
+    case 'follow':
+      return (
+        <Container>
+          <BackBtn type="button" onClick={leftOnClick} />
+          <CenterText>{text}</CenterText>
+        </Container>
+      );
+    case 'btn':
+      return (
+        <Container $justify="end">
+          <Button size="sm" text={btnText} onClick={rightOnClick} />
+        </Container>
+      );
+    case 'chatroom':
+      return (
+        <Container $justify="space-between">
+          <BackBtn type="button" onClick={leftOnClick} />
+          <LeftText>{text}</LeftText>
+          <EditBtn type="button" onClick={rightOnClick} />
+        </Container>
+      );
     default:
-      return <Container></Container>;
+      return (
+        <Container $justify="space-between">
+          <BackBtn type="button" onClick={leftOnClick} />
+          <EditBtn type="button" onClick={rightOnClick} />
+        </Container>
+      );
   }
 }

--- a/src/components/common/header/Header.style.js
+++ b/src/components/common/header/Header.style.js
@@ -44,7 +44,7 @@ export const SerachInput = styled.input`
   padding: 8px 16px;
 
   &::placeholder {
-    color: #c4c4c4;
+    color: var(--gray-04);
   }
 `;
 

--- a/src/components/common/header/Header.style.js
+++ b/src/components/common/header/Header.style.js
@@ -1,19 +1,23 @@
 import { styled } from 'styled-components';
 import iconSerch from 'assets/images/icon_search.png';
 import iconBack from 'assets/images/icon_arrow_left.png';
+import iconMore from 'assets/images/icon_more_vertical_small.png';
 
 export const Container = styled.div`
   width: 100%;
   height: 48px;
   border-bottom: 1px solid var(--gray-02);
+  background-color: var(--white);
   display: flex;
-  justify-content: space-between;
+  justify-content: ${(props) => props.$justify};
   align-items: center;
+  position: relative;
+  padding: 0 16px;
 `;
 
 export const Logo = styled.img`
   width: 85px;
-  margin-left: 15px;
+  margin-left: -1px;
 `;
 
 export const SearchBtn = styled.button`
@@ -21,7 +25,6 @@ export const SearchBtn = styled.button`
   height: 24px;
   background: url(${iconSerch}) no-repeat;
   background-size: cover;
-  margin-right: 16px;
 `;
 
 export const BackBtn = styled.button`
@@ -29,21 +32,45 @@ export const BackBtn = styled.button`
   height: 22px;
   background: url(${iconBack}) no-repeat;
   background-size: cover;
-  margin-left: 16px;
-  margin-right: 20px;
 `;
 
 export const SerachInput = styled.input`
-  width: 100%;
+  width: 316px;
   background-color: var(--gray-03);
   border: none;
   border-radius: 32px;
   font-size: 14px;
   color: var(--black);
   padding: 8px 16px;
-  margin-right: 16px;
 
   &::placeholder {
     color: #c4c4c4;
   }
+`;
+
+export const CenterText = styled.h1`
+  color: var(--black);
+  font-size: 14px;
+  font-weight: var(--medium);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;
+
+export const LeftText = styled.h1`
+  color: var(--black);
+  font-size: 14px;
+  font-weight: var(--medium);
+  position: absolute;
+  top: 50%;
+  left: 48px;
+  transform: translateY(-50%);
+`;
+
+export const EditBtn = styled.button`
+  width: 24px;
+  height: 24px;
+  background: url(${iconMore}) no-repeat;
+  background-size: cover;
 `;

--- a/src/components/common/navbar/NavBar.jsx
+++ b/src/components/common/navbar/NavBar.jsx
@@ -16,19 +16,19 @@ export default function NavBar() {
     <Container>
       <NavLink to="/home">
         <NavIcon src={pathname === '/home' ? iconHomeFill : iconHome} />
-        <NavText color={pathname === '/home' ? true : false}>홈</NavText>
+        <NavText $textcolor={pathname === '/home' ? 'var(--main-color-01)' : 'var(--gray-01)'}>홈</NavText>
       </NavLink>
       <NavLink to="/chat">
         <NavIcon src={pathname === '/chat' ? iconChatFill : iconChat} />
-        <NavText color={pathname === '/chat' ? true : false}>채팅</NavText>
+        <NavText $textcolor={pathname === '/chat' ? 'var(--main-color-01)' : 'var(--gray-01)'}>채팅</NavText>
       </NavLink>
       <NavLink to="/post/upload">
         <NavIcon src={iconEdit} />
-        <NavText color={false}>게시물 작성</NavText>
+        <NavText $textcolor="var(--gray-01)">게시물 작성</NavText>
       </NavLink>
       <NavLink to="/profile">
         <NavIcon src={pathname === '/profile' ? iconOguFill : iconOgu} />
-        <NavText color={pathname === '/profile' ? true : false}>프로필</NavText>
+        <NavText $textcolor={pathname === '/profile' ? 'var(--main-color-01)' : 'var(--gray-01)'}>프로필</NavText>
       </NavLink>
     </Container>
   );

--- a/src/components/common/navbar/NavBar.style.js
+++ b/src/components/common/navbar/NavBar.style.js
@@ -31,7 +31,7 @@ export const NavIcon = styled.img`
 `;
 
 export const NavText = styled.span`
-  color: ${(props) => (props.color ? 'var(--main-color-01)' : 'var(--gray-01)')};
+  color: ${(props) => props.$textcolor};
   font-size: 10px;
   text-align: center;
 `;

--- a/src/style/GlobalStyle.js
+++ b/src/style/GlobalStyle.js
@@ -16,6 +16,7 @@ const GlobalStyle = createGlobalStyle`
         --gray-01: #767676;
         --gray-02: #DBDBDB;
         --gray-03: #F2F2F2;
+        --gray-04: #c4c4c4;
 
         /*---------- Font ----------*/
         --main-font: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -81,7 +81,9 @@ summary,
 time,
 mark,
 audio,
-video {
+video,
+form,
+textarea {
   margin: 0;
   padding: 0;
   border: 0;
@@ -110,7 +112,8 @@ body {
 }
 
 ol,
-ul {
+ul,
+li {
   list-style: none;
 }
 


### PR DESCRIPTION
- 버튼 크기별로 return해주는 버튼컴포넌트
- 헤더 타입별로 return해주는 헤더컴포넌트
- 하단메뉴탭 수정

> ### 잠깐! PR하기 전에 확인해주세요!

✅ PR 제목의 형식을 잘 작성했나요?(커밋메시지 컨벤션과 동일)   
✅ 불필요한 코드를 제거했나요?   
✅ 작업 시작 전 후로 develop브랜치가 최신상태임을 확인했나요?   
✅ 라벨은 등록했나요?   
<br>

✨ PR 한 줄 요약
-------------------------------------------------
공통컴포넌트 UI(버튼,헤더) 타입과 사이즈별로 구현

<br>
<br>

🛠 상세 작업 내용
-------------------------------------------------  
- 버튼 크기별로 return해주는 버튼컴포넌트
- 헤더 타입별로 return해주는 헤더컴포넌트
- 하단메뉴탭 수정

<br>
<br>

📸 참고 사항
-------------------------------------------------
![image](https://github.com/FRONTENDSCHOOL7/final-05-oguogu/assets/53458437/dc78dd12-86e3-4aee-808f-0195ebcf9981)

사용코드는 피그마 참고. -> 검정네모박스 부분이 디폴트입니다.


<br>
<br>


💡 관련 이슈
-------------------------------------------------
#12 

<br>
<br>
