### PR TITLE
✨ Feat      : ChatPage 헤더부분 컴포넌트로 변경, List 컴포넌트 조건부스타일렌더링 props로 변경

### DIFF
--- a/src/pages/ChatPage/ChatList.jsx
+++ b/src/pages/ChatPage/ChatList.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
-import { List, Box, Content, Bg, Header } from 'pages/ChatPage/ChatPage.style';
-import iconArrowLeft from 'assets/images/icon_arrow_left.png';
-import iconMore from 'assets/images/icon_more_vertical_small.png';
+import Header from 'components/common/header/Header';
+import { List, Box, Content, Bg } from 'pages/ChatPage/ChatPage.style';
 import iconChatEllipse from 'assets/images/icon_chat_ellipse.png';
 import iconChatPink from 'assets/images/icon_chat_pink.png';
 import { useNavigate } from 'react-router-dom';
@@ -32,7 +31,7 @@ function ChatList() {
 
   const listItem = contents.map((item) => {
     return (
-      <List key={item.id} id={item.id} onMouseDown={handleListClick} onMouseUp={handleLink} className={selectedItem === item.id ? 'selected' : ''}>
+      <List key={item.id} id={item.id} onMouseDown={handleListClick} onMouseUp={handleLink} selectedItem={selectedItem}>
         {item.img}
         <Box>
           <strong>{item.accountId}</strong>
@@ -47,10 +46,7 @@ function ChatList() {
 
   return (
     <Bg>
-      <Header>
-        <img src={iconArrowLeft} alt="되돌아가기" style={{ width: '22px' }} />
-        <img src={iconMore} alt="편집하기" style={{ width: '24px' }} />
-      </Header>
+      <Header />
       <ul>{listItem}</ul>
     </Bg>
   );

--- a/src/pages/ChatPage/ChatPage.style.jsx
+++ b/src/pages/ChatPage/ChatPage.style.jsx
@@ -19,7 +19,7 @@ export const List = styled.li`
   width: 100%;
   padding: 13px 16px 13px 16px;
   border-bottom: 0.5px solid var(--gray-02);
-  background-color: ${(props) => (props.selectedItem === props.id ? 'var(--main-color-02)' : '')};
+ background-color: ${(props) => props.selectedItem === props.id && 'var(--main-color-02)'};
 `;
 
 export const Box = styled.div`

--- a/src/pages/ChatPage/ChatPage.style.jsx
+++ b/src/pages/ChatPage/ChatPage.style.jsx
@@ -11,14 +11,6 @@ export const Bg = styled.section`
   background: var(--main-color-03);
 `;
 
-export const Header = styled.header`
-  display: flex;
-  justify-content: space-between;
-  padding: 12px;
-  background-color: var(--white);
-  border-bottom: 0.5px solid var(--gray-02);
-`;
-
 export const List = styled.li`
   display: flex;
   flex-direction: row;
@@ -27,9 +19,7 @@ export const List = styled.li`
   width: 100%;
   padding: 13px 16px 13px 16px;
   border-bottom: 0.5px solid var(--gray-02);
-  &.selected {
-    background-color: var(--main-color-02);
-  }
+  background-color: ${(props) => (props.selectedItem === props.id ? 'var(--main-color-02)' : '')};
 `;
 
 export const Box = styled.div`

--- a/src/pages/ChatPage/ChatRoom.jsx
+++ b/src/pages/ChatPage/ChatRoom.jsx
@@ -1,16 +1,14 @@
 import React, { useState } from 'react';
-import { List, Box, Content, Bg, Header } from 'pages/ChatPage/ChatPage.style';
-import iconArrowLeft from 'assets/images/icon_arrow_left.png';
-import iconMore from 'assets/images/icon_more_vertical_small.png';
+import Header from 'components/common/header/Header';
+import { List, Box, Content, Bg } from 'pages/ChatPage/ChatPage.style';
 
 function ChatRoom() {
   return (
-    <Bg>
-      <Header>
-        <img src={iconArrowLeft} alt="되돌아가기" style={{ width: '22px' }} />
-        <img src={iconMore} alt="편집하기" style={{ width: '24px' }} />
-      </Header>
-    </Bg>
+    <>
+      <Bg>
+        <Header />
+      </Bg>
+    </>
   );
 }
 


### PR DESCRIPTION
1. ChatPage내 코드로 작성한 헤더 -> 헤더컴포넌트(components/common/header.jsx)로 교체
2. ChatList의 List 컴포넌트부분 변경사항 : 클래스네임으로 설정했던 조건부스타일렌더링을 props로 바꾸었음

> ### 잠깐! PR하기 전에 확인해주세요!

✅ PR 제목의 형식을 잘 작성했나요?(커밋메시지 컨벤션과 동일)   
✅ 불필요한 코드를 제거했나요?   
✅ 작업 시작 전 후로 develop브랜치가 최신상태임을 확인했나요?   
✅ 라벨은 등록했나요?   
<br>

✨ PR 한 줄 요약
-------------------------------------------------
ChatPage 헤더부분 컴포넌트로 변경, List 컴포넌트 조건부스타일렌더링 props로 변경
<br>
<br>

🛠 상세 작업 내용
-------------------------------------------------  
- 채팅리스트 : 헤더코드를 공통컴포넌트헤더로 바꾸기
-  채팅리스트 : 스타일드컴포넌트에 클래스네임 썼던 부분 프롭스로 바꾸기
<br>
<br>

📸 참고 사항
-------------------------------------------------
![image](https://github.com/FRONTENDSCHOOL7/final-05-oguogu/assets/129969049/4f997ace-3e75-4adf-9bba-d832ca2911c2)

![image](https://github.com/FRONTENDSCHOOL7/final-05-oguogu/assets/129969049/99ed26dd-a61a-4488-8f44-8af0373807ed)


<br>
<br>


💡 관련 이슈
-------------------------------------------------
[Feature] 채팅목록페이지 구현 #2 
[Feature] 공통컴포넌트(버튼,헤더) 작업 #12 
<br>
<br>
