### PR TITLE
♻️  Refactor : 뒤로가기 버튼 헤더로부터 분리

### DIFF
--- a/src/components/common/button/Button.jsx
+++ b/src/components/common/button/Button.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { ShadowButton, BasicButton, BASIC_BTN, SHADOW_BTN, BorderButton, BORDER_BTN } from './Button.style';
+import { ShadowButton, BasicButton, BASIC_BTN, SHADOW_BTN, BorderButton, BORDER_BTN, BackBtn } from 'components/common/button/Button.style';
 
 export default function Button({ size, vari, type, text, onClick, disabled }) {
   //버튼사이즈종류 : lg,md,sm,xs,md-shadow,sm-shadow,md-border,sm-border,xs-border
   switch (vari) {
+    case 'back':
+      return <BackBtn type="button" onClick={onClick} />;
     case 'shadow':
       return (
         <ShadowButton $size={SHADOW_BTN[size]} type={type} onClick={onClick} disabled={disabled}>

--- a/src/components/common/button/Button.style.jsx
+++ b/src/components/common/button/Button.style.jsx
@@ -1,4 +1,5 @@
 import { css, styled } from 'styled-components';
+import iconBack from 'assets/images/icon_arrow_left.png';
 
 export const BASIC_BTN = {
   xs: css`
@@ -89,4 +90,11 @@ export const BorderButton = styled.button`
   color: ${(props) => (props.$pink ? 'var(--main-color-01)' : 'var(--gray-01)')};
   background-color: var(--white);
   ${(props) => props.$size}
+`;
+
+export const BackBtn = styled.button`
+  width: 22px;
+  height: 22px;
+  background: url(${iconBack}) no-repeat;
+  background-size: cover;
 `;

--- a/src/components/common/header/Header.jsx
+++ b/src/components/common/header/Header.jsx
@@ -1,9 +1,14 @@
 import React from 'react';
-import { BackBtn, CenterText, Container, EditBtn, LeftText, Logo, SearchBtn, SerachInput } from 'components/common/header/Header.style';
+import { CenterText, Container, EditBtn, LeftText, Logo, SearchBtn, SerachInput } from 'components/common/header/Header.style';
 import logo from 'assets/images/logo_oguogu.png';
 import Button from 'components/common/button/Button';
+import { useNavigate } from 'react-router';
 
 export default function Header({ type, text, btnText, rightOnClick, leftOnClick }) {
+  const navigate = useNavigate();
+  const toBack = () => {
+    navigate(-1);
+  };
   switch (type) {
     case 'home':
       return (
@@ -16,28 +21,28 @@ export default function Header({ type, text, btnText, rightOnClick, leftOnClick 
     case 'search':
       return (
         <Container $justify="space-between">
-          <BackBtn type="button" onClick={leftOnClick} />
+          <Button vari="back" onClick={toBack} />
           <SerachInput placeholder="계정 검색" />
         </Container>
       );
     case 'follow':
       return (
         <Container>
-          <BackBtn type="button" onClick={leftOnClick} />
+          <Button vari="back" />
           <CenterText>{text}</CenterText>
         </Container>
       );
     case 'btn':
       return (
         <Container $justify="space-between">
-          <BackBtn type="button" onClick={leftOnClick} />
+          <Button vari="back" onClick={toBack} />
           <Button size="sm" text={btnText} onClick={rightOnClick} />
         </Container>
       );
     case 'chatroom':
       return (
         <Container $justify="space-between">
-          <BackBtn type="button" onClick={leftOnClick} />
+          <Button vari="back" onClick={toBack} />
           <LeftText>{text}</LeftText>
           <EditBtn type="button" onClick={rightOnClick} />
         </Container>
@@ -45,7 +50,7 @@ export default function Header({ type, text, btnText, rightOnClick, leftOnClick 
     default:
       return (
         <Container $justify="space-between">
-          <BackBtn type="button" onClick={leftOnClick} />
+          <Button vari="back" onClick={toBack} />
           <EditBtn type="button" onClick={rightOnClick} />
         </Container>
       );

--- a/src/components/common/header/Header.style.js
+++ b/src/components/common/header/Header.style.js
@@ -1,6 +1,5 @@
 import { styled } from 'styled-components';
 import iconSerch from 'assets/images/icon_search.png';
-import iconBack from 'assets/images/icon_arrow_left.png';
 import iconMore from 'assets/images/icon_more_vertical_small.png';
 
 export const Container = styled.div`
@@ -24,13 +23,6 @@ export const SearchBtn = styled.button`
   width: 24px;
   height: 24px;
   background: url(${iconSerch}) no-repeat;
-  background-size: cover;
-`;
-
-export const BackBtn = styled.button`
-  width: 22px;
-  height: 22px;
-  background: url(${iconBack}) no-repeat;
   background-size: cover;
 `;
 


### PR DESCRIPTION
뒤로가기 버튼 헤더로부터 분리함으로써 헤더 외의 다른 페이지에서도 뒤로가기 버튼을 사용할 수 있도록 해 재사용성을 높임

> ### 잠깐! PR하기 전에 확인해주세요!

✅ PR 제목의 형식을 잘 작성했나요?(커밋메시지 컨벤션과 동일)   
✅ 불필요한 코드를 제거했나요?   
✅ 작업 시작 전 후로 develop브랜치가 최신상태임을 확인했나요?   
✅ 라벨은 등록했나요?   
<br>

✨ PR 한 줄 요약
-------------------------------------------------
뒤로가기 버튼 헤더로부터 분리

<br>
<br>

🛠 상세 작업 내용
-------------------------------------------------  
버튼 vari 에 back 추가
헤더스타일파일에 있던 BackButton 컴포넌트 버튼 컴포넌트로 이동

<br>
<br>

📸 참고 사항
-------------------------------------------------
<!--여기에 작성해주세요-->

<br>
<br>


💡 관련 이슈
-------------------------------------------------
<!--여기에 작성해주세요-->

<br>
<br>
